### PR TITLE
feat: Adding template for additional tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.1.0",
-        "dockerode": "^3.3.1"
+        "dockerode": "^3.3.1",
+        "lodash": "4.17.21"
       },
       "devDependencies": {
         "@commitlint/cli": "16.1.0",
@@ -5163,8 +5164,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -14555,8 +14555,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@semantic-release/error": "^3.0.0",
     "aggregate-error": "^3.1.0",
-    "dockerode": "^3.3.1"
+    "dockerode": "^3.3.1",
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@commitlint/cli": "16.1.0",

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -1,5 +1,6 @@
 const AggregateError = require('aggregate-error')
 const Dockerode = require('dockerode')
+const { template } = require('lodash')
 
 const getError = require('./get-error')
 
@@ -24,7 +25,8 @@ module.exports = async (pluginConfig, ctx) => {
     }
     const baseImageTag =
       ctx.env.DOCKER_BASE_IMAGE_TAG || pluginConfig.baseImageTag || 'latest'
-    for (const tag of tags) {
+    for (let tag of tags) {
+      tag = template(tag)(ctx)
       ctx.logger.log(
         `Tagging docker image ${pluginConfig.baseImageName}:${baseImageTag} to ${pluginConfig.baseImageName}:${tag}`,
       )

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -25,17 +25,21 @@ module.exports = async (pluginConfig, ctx) => {
     }
     const baseImageTag =
       ctx.env.DOCKER_BASE_IMAGE_TAG || pluginConfig.baseImageTag || 'latest'
+    if (!ctx.nextRelease.channel) {
+      tags.push(baseImageTag)
+    }
     for (let tag of tags) {
       tag = template(tag)(ctx)
       ctx.logger.log(
-        `Tagging docker image ${pluginConfig.baseImageName}:${baseImageTag} to ${pluginConfig.baseImageName}:${tag}`,
+        `Tagging docker image ${pluginConfig.baseImageName} to ${pluginConfig.baseImageName}:${tag}`,
       )
       await image.tag({ repo: pluginConfig.baseImageName, tag })
     }
     for (const { imageName } of pluginConfig.registries) {
-      for (const tag of [...tags, baseImageTag]) {
+      for (let tag of tags) {
+        tag = template(tag)(ctx)
         ctx.logger.log(
-          `Tagging docker image ${pluginConfig.baseImageName}:${baseImageTag} to ${imageName}:${tag}`,
+          `Tagging docker image ${pluginConfig.baseImageName} to ${imageName}:${tag}`,
         )
         await image.tag({ repo: imageName, tag })
       }

--- a/src/publish.js
+++ b/src/publish.js
@@ -51,7 +51,10 @@ module.exports = async (pluginConfig, ctx) => {
     const docker = new Dockerode()
     const baseImageTag =
       ctx.env.DOCKER_BASE_IMAGE_TAG || pluginConfig.baseImageTag || 'latest'
-    const tags = [baseImageTag, ctx.nextRelease.version]
+    const tags = [ctx.nextRelease.version]
+    if (!ctx.nextRelease.channel) {
+      tags.push(baseImageTag)
+    }
     if (pluginConfig.additionalTags && pluginConfig.additionalTags.length > 0) {
       tags.push(...pluginConfig.additionalTags)
     }

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,5 +1,6 @@
 const AggregateError = require('aggregate-error')
 const Dockerode = require('dockerode')
+const { template } = require('lodash')
 
 const getError = require('./get-error')
 const getAuth = require('./getAuth')
@@ -68,7 +69,8 @@ module.exports = async (pluginConfig, ctx) => {
         serveraddress: url,
         username: user,
       }
-      for (const tag of tags) {
+      for (let tag of tags) {
+        tag = template(tag)(ctx)
         if (isTagPushAllowed(tag, registry)) {
           ctx.logger.log(`Pushing docker image ${imageName}:${tag}`)
           const response = await image.push({ tag, ...options })

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -73,12 +73,15 @@ describe('Publish', () => {
 
   it('expect success publish', async () => {
     pluginConfig.registries[0].url = 'registry.example.com'
-    pluginConfig.additionalTags = ['beta']
+    // eslint-disable-next-line no-template-curly-in-string
+    pluginConfig.additionalTags = ['beta', 'beta-${nextRelease.version}']
     expect(await publish(pluginConfig, ctx)).to.be.a('undefined')
     // eslint-disable-next-line no-unused-expressions
     expect(isTagPublished('latest')).to.be.true
     // eslint-disable-next-line no-unused-expressions
     expect(isTagPublished('beta')).to.be.true
+    // eslint-disable-next-line no-unused-expressions
+    expect(isTagPublished('beta-1.0.0')).to.be.true
   })
 
   it('expect skip "latest" publish', async () => {


### PR DESCRIPTION
**The case**
The current implementation takes a few assumptions that do not allow to fully benefit from the [semantic-release workflow channels](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/release-workflow/distribution-channels.md#releasing-a-feature-on-next):

- `latest` is a default tag, it cannot be removed
- `x.x.x` (the version) is always used, it cannot be removed

While in most of the cases the above makes sense, there are others cases that may require to have better control over which tag to use during the publishing. The distribution channels allow to publish an higher version but targeting a specific channel.

For example, having a _latest_ 1.0.1 version there could be the desire to publish an higher 2.0.0 but on _next_.
The desired behaviour would be to publish the 2.0.0:

- using a tag `2.0.0`
- using a tag `next`
- without using a tag `latest`
- and possibly even tagging using a shorter version such as `2.0` or `2`

**The solution**
To enable additional tagging capabilities, I used the [same technique that semantic-release/exec uses](https://github.com/semantic-release/exec/blob/009836476c5c0c796cc87249018cfd1eec3f4cd5/lib/exec.js#L7). This way it is possible to do:
  - Assign the `latest` tag only when the `nextRelease.channgel` is undefined
  - take advantage of the [auto assigned channel](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel) given by the branch configuration

    ```js
    {
      "plugins": [
        [
          "@eclass/semantic-release-docker",
          {
            "additionalTags": [
                "${nextRelease.version}",
                "${nextRelease.channel}" // next or latest
            ]
          }
        ]
      ]
    }
    ```
  - or even cover more specific cases

    ```javascript
    {
      "plugins": [
        [
          "@eclass/semantic-release-docker",
          {
            "additionalTags": [
                "${nextRelease.version.split('.').slice(0, 2).join('.')}" // from 2.0.0 to 2.0
            ]
          }
        ]
      ]
    }
    ```
